### PR TITLE
Missing period in the README made the quick copy/paste of the instruc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cd amazon-bedrock-audio-summarizer
 
 Create a virtual env:
 ```
-python3 -m venv venv
+python3 -m venv .venv
 ``` 
 
 Activate your virtual env:


### PR DESCRIPTION
…tions not work.

I was rapid fire copying and pasting the commands with the copy button but the activation of the venv was looking for .venv instead of the venv that was created.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
